### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/account.js
+++ b/account.js
@@ -1,7 +1,7 @@
 var Waterline = require("waterline");
 var sailsMemoryAdapter = require("sails-memory");
 var async = require("async");
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 module.exports = ServerAccount;
 

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "bunyan": "^1.8.1",
     "lodash": "^4.11.2",
     "mds-client": "^1.1.1",
-    "node-uuid": "^1.4.7",
     "rc": "^1.1.6",
     "restify": "^4.0.4",
     "sails-disk": "^0.10.9",
+    "uuid": "^3.0.0",
     "waterline": "^0.12.1"
   }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.